### PR TITLE
added descriptors descriptions

### DIFF
--- a/bleak/backends/bluezdbus/descriptor.py
+++ b/bleak/backends/bluezdbus/descriptor.py
@@ -1,4 +1,5 @@
 from bleak.backends.descriptor import BleakGATTDescriptor
+from bleak.uuids import uuidstr_to_str
 
 
 class BleakGATTDescriptorBlueZDBus(BleakGATTDescriptor):
@@ -41,3 +42,8 @@ class BleakGATTDescriptorBlueZDBus(BleakGATTDescriptor):
     def path(self) -> str:
         """The DBus path. Mostly needed by `bleak`, not by end user"""
         return self.__path
+
+    @property
+    def description(self) -> str:
+        """Description for this descriptor"""
+        return uuidstr_to_str(self.uuid)

--- a/bleak/backends/corebluetooth/descriptor.py
+++ b/bleak/backends/corebluetooth/descriptor.py
@@ -7,6 +7,7 @@ Created on 2019-06-28 by kevincar <kevincarrolldavis@gmail.com>
 from Foundation import CBDescriptor
 
 from bleak.backends.descriptor import BleakGATTDescriptor
+from bleak.uuids import uuidstr_to_str
 
 
 class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):
@@ -42,3 +43,9 @@ class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):
     def handle(self) -> int:
         """Integer handle for this descriptor"""
         return int(self.obj.handle())
+
+    @property
+    def description(self) -> str:
+        """Description for this descriptor"""
+        # No description available in Core Bluetooth backend.
+        return uuidstr_to_str(self.uuid)

--- a/bleak/utils.py
+++ b/bleak/utils.py
@@ -9,7 +9,7 @@ try:
     import bleak_sigspec
     CHARS_XML_DIR = "{}/characteristics_xml".format(bleak_sigspec.__path__[0])
 except Exception as e:
-    CHARS_XML_DIR = None
+    CHARS_XML_DIR = '.'
 
 # UNITS
 
@@ -143,8 +143,8 @@ DATA_FMT = {
 class CHAR_XML:
     """Parse characteristic xml file"""
 
-    def __init__(self, xml_file):
-        self._tree = ET.parse("{}/{}".format(CHARS_XML_DIR, xml_file))
+    def __init__(self, xml_file, path=CHARS_XML_DIR):
+        self._tree = ET.parse("{}/{}".format(path, xml_file))
         self._root = self._tree.getroot()
         self.char_metadata = None
         self.name = None

--- a/bleak/uuids.py
+++ b/bleak/uuids.py
@@ -148,8 +148,8 @@ uuid16_dict = {
     0x2901: "Characteristic User Description",
     0x2902: "Client Characteristic Configuration",
     0x2903: "Server Characteristic Configuration",
-    0x2904: "Characteristic Format",
-    0x2905: "Characteristic Aggregate Formate",
+    0x2904: "Characteristic Presentation Format",
+    0x2905: "Characteristic Aggregate Format",
     0x2906: "Valid Range",
     0x2907: "External Report Reference",
     0x2908: "Report Reference",
@@ -634,6 +634,20 @@ uuid16_dict = {
     0xFFFC: "AirFuel Alliance",
     0xFFFE: "Alliance for Wireless Power (A4WP)",
     0xFFFD: "Fast IDentity Online Alliance (FIDO)",
+    # Descriptors (SIG)
+    0x2900: 'Characteristic Extended Properties',
+    0x2901: 'Characteristic User Description',
+    0x2902: 'Client Characteristic Configuration',
+    0x290B: 'Environmental Sensing Configuration',
+    0x290C: 'Environmental Sensing Measurement',
+    0x290D: 'Environmental Sensing Trigger Setting',
+    0x2907: 'External Report Reference',
+    0x2909: 'Number of Digitals',
+    0x2908: 'Report Reference',
+    0x2903: 'Server Characteristic Configuration',
+    0x290E: 'Time Trigger Setting',
+    0x2906: 'Valid Range',
+    0x290A: 'Value Trigger Setting'
 }
 
 uuid128_dict = {

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -61,8 +61,8 @@ async def run(address, loop, debug=False):
                 for descriptor in char.descriptors:
                     value = await client.read_gatt_descriptor(descriptor.handle)
                     log.info(
-                        "\t\t[Descriptor] {0}: (Handle: {1}) | Value: {2} ".format(
-                            descriptor.uuid, descriptor.handle, bytes(value)
+                        "\t\t[Descriptor] {0}: (Handle: {1}) | Name: {2}, Value: {3} ".format(
+                            descriptor.uuid, descriptor.handle, descriptor.description, bytes(value)
                         )
                     )
 
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     address = (
         "24:71:89:cc:09:05"
         if platform.system() != "Darwin"
-        else "8214E9EA-FE22-450C-B257-F105057EBF31"
+        else "81C309C0-2DF5-42BA-81BF-8B8112E026A7"
     )
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run(address, loop, True))


### PR DESCRIPTION
This adds missing descriptors uuids to `uuid16_dict` and now `descriptor.description` returns the proper description name.
e.g.

```
$ python3.8 service_explorer.py
Connected: True
[Service] 180F: Battery Service
        [Characteristic] 00002a19-0000-1000-8000-00805f9b34fb: (Handle: 41) (read) | Name: Battery Level, Value: Level: 96 %
        [Characteristic] 00002a1a-0000-1000-8000-00805f9b34fb: (Handle: 43) (read,notify) | Name: Battery Power State, Value: State: {'BitGroup 0': 'Present', 'BitGroup 2': 'Not Discharging', 'BitGroup 4':
'Charging (Chargeable)', 'BitGroup 6': 'Good Level'}
                [Descriptor] 2902: (Handle: 45) | Name: Client Characteristic Configuration, Value: b'\x00\x00'
[Service] 180A: Device Information
        [Characteristic] 00002a29-0000-1000-8000-00805f9b34fb: (Handle: 47) (read) | Name: Manufacturer Name String, Value: Manufacturer Name: LG Electronics
        [Characteristic] 00002a01-0000-1000-8000-00805f9b34fb: (Handle: 49) (read) | Name: Appearance, Value: Category: Generic Phone
        [Characteristic] 00002a24-0000-1000-8000-00805f9b34fb: (Handle: 51) (read) | Name: Model Number String, Value: Model Number: LG-H870
        [Characteristic] 00002a26-0000-1000-8000-00805f9b34fb: (Handle: 53) (read) | Name: Firmware Revision String, Value: Firmware Revision: Android 9
[Service] 181A: Environmental Sensing
[Characteristic] 00002a6e-0000-1000-8000-00805f9b34fb: (Handle: 56) (read,notify) | Name: Temperature, Value: Temperature: 25.0 °C
                [Descriptor] 2902: (Handle: 58) | Name: Client Characteristic Configuration, Value: b'\x00\x00'
                [Descriptor] 2901: (Handle: 59) | Name: Characteristic User Description, Value: b'Phone temperature'
[Service] 1804: Tx Power
        [Characteristic] 00002a07-0000-1000-8000-00805f9b34fb: (Handle: 61) (read) | Name: Tx Power Level, Value: Tx Power: 0 dBm